### PR TITLE
chore: updated roverlib-go to 1.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.10
 
 require (
 	github.com/VU-ASE/rovercom v1.5.1
-	github.com/VU-ASE/roverlib-go v1.2.0
+	github.com/VU-ASE/roverlib-go v1.2.6
 	github.com/rs/zerolog v1.33.0
 	gocv.io/x/gocv v0.39.0
 	google.golang.org/protobuf v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/VU-ASE/rovercom v1.5.1 h1:2lbaZ0ZS1AC8XamyBzCKAsvKX7JFiTibS/fdWdKRwtU
 github.com/VU-ASE/rovercom v1.5.1/go.mod h1:1T9bXpOPMMkubm6YBa847vseBRALFzq8lkDx96w0Hr8=
 github.com/VU-ASE/roverlib-go v1.2.0 h1:52fEzJAExaWqOLy0meBmAExWBEOnrxAsIzQK0ErdM3k=
 github.com/VU-ASE/roverlib-go v1.2.0/go.mod h1:wCre2f0pgcCOjM+9HPNdWxqF/ZsS/EgEyy6bJWjXjW0=
+github.com/VU-ASE/roverlib-go v1.2.6 h1:2AxTKCJeOt1XT1O6q5nMQmSrbOfrlBhgS/mBf3rZ6JE=
+github.com/VU-ASE/roverlib-go v1.2.6/go.mod h1:wCre2f0pgcCOjM+9HPNdWxqF/ZsS/EgEyy6bJWjXjW0=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=

--- a/src/main.go
+++ b/src/main.go
@@ -115,7 +115,7 @@ func run(service roverlib.Service, configuration *roverlib.ServiceConfiguration)
 		}
 
 		if curr != newVal {
-			log.Info().Msgf("Tunable number updated: %s -> %s", curr, newVal)
+			log.Info().Msgf("Tunable number updated: %f -> %f", curr, newVal)
 			curr = newVal
 		}
 		tunableSpeed = curr


### PR DESCRIPTION
Updating the roverlib-go version to the newest one currently.